### PR TITLE
feat: add build process for capmvm compatible kubernetes images

### DIFF
--- a/.github/workflows/capmvm-kubernetes.yml
+++ b/.github/workflows/capmvm-kubernetes.yml
@@ -1,0 +1,39 @@
+name: Build and release capmvm kubernetes images
+
+on:
+  pull_request:
+    paths:
+      - 'capmvm/kubernetes/**'
+    branches: [main]
+  push:
+    paths:
+      - 'capmvm/kubernetes/**'
+    branches: [main]
+
+defaults:
+  run:
+    working-directory: capmvm/kubernetes
+
+jobs:
+  build:
+    if: github.event_name != 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build image
+        run: make
+  release:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Login to container registry
+        uses: docker/login-action@v1.10.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        run: |
+          make
+          make push

--- a/capmvm/kubernetes/Dockerfile
+++ b/capmvm/kubernetes/Dockerfile
@@ -1,0 +1,52 @@
+FROM ghcr.io/weaveworks/flintlock-ubuntu-base:20.04
+
+ARG ARCH="amd64"
+ARG CONTAINERD_VERSION=1.5.9
+# Kubernetes version will be used to keep the kubeadm, kubelet, and kubectl version consistent
+ARG KUBERNETES_VERSION=1.21.8
+
+
+RUN apt-get update && apt-get install -y \
+        wget \
+        apt-transport-https \
+        ca-certificates \
+        gnupg2 \
+        software-properties-common \
+        libseccomp2
+
+#### Let iptables see bridged traffic ###
+RUN echo "overlay \n\
+br_netfilter" >> /etc/modules-load.d/containerd.conf
+
+# Setup required sysctl params, these persist across reboots.
+RUN echo "net.bridge.bridge-nf-call-iptables  = 1 \n\
+net.ipv4.ip_forward                 = 1 \n\
+net.bridge.bridge-nf-call-ip6tables = 1" >> /etc/sysctl.d/99-kubernetes-cri.conf
+
+# Apply sysctl params without reboot
+RUN sysctl --system
+
+# Install Containerd
+RUN wget https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/cri-containerd-cni-${CONTAINERD_VERSION}-linux-${ARCH}.tar.gz
+RUN tar --no-overwrite-dir -C / -xzf cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz && rm -f cri-containerd-cni-${CONTAINERD_VERSION}-linux-amd64.tar.gz
+
+### Add apt repos
+# Kubeadm, Kubelet, and Kubectl
+RUN curl -fsSLo /usr/share/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+RUN apt-get update && apt-get install -y \
+        kubeadm=${KUBERNETES_VERSION}-00 \
+        kubelet=${KUBERNETES_VERSION}-00 \
+        kubectl=${KUBERNETES_VERSION}-00 && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/containerd && containerd config default > /etc/containerd/config.toml
+RUN systemctl enable containerd
+
+RUN echo '[Service] \n\
+Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock\"' \
+    >> /etc/systemd/system/kubelet.service.d/0-containerd.conf
+
+RUN systemctl enable kubelet

--- a/capmvm/kubernetes/Dockerfile
+++ b/capmvm/kubernetes/Dockerfile
@@ -46,7 +46,7 @@ RUN mkdir -p /etc/containerd && containerd config default > /etc/containerd/conf
 RUN systemctl enable containerd
 
 RUN echo '[Service] \n\
-Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock\"' \
+Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"' \
     >> /etc/systemd/system/kubelet.service.d/0-containerd.conf
 
 RUN systemctl enable kubelet

--- a/capmvm/kubernetes/Dockerfile
+++ b/capmvm/kubernetes/Dockerfile
@@ -1,5 +1,6 @@
 FROM ghcr.io/weaveworks/flintlock-ubuntu-base:20.04
 
+
 ARG ARCH="amd64"
 ARG CONTAINERD_VERSION=1.5.9
 # Kubernetes version will be used to keep the kubeadm, kubelet, and kubectl version consistent
@@ -12,7 +13,8 @@ RUN apt-get update && apt-get install -y \
         ca-certificates \
         gnupg2 \
         software-properties-common \
-        libseccomp2
+        libseccomp2 \
+        jq
 
 #### Let iptables see bridged traffic ###
 RUN echo "overlay \n\

--- a/capmvm/kubernetes/Makefile
+++ b/capmvm/kubernetes/Makefile
@@ -1,0 +1,17 @@
+DOCKER := docker
+
+REGISTRY?=ghcr.io/weaveworks
+IMAGE_NAME?=$(REGISTRY)/capmvm-kubernetes
+RELEASE?=1.21.8 # RELEASE follows the kubernetes release
+CONTAINERD_VERSION?=1.5.9
+TAG?=$(shell git rev-parse --short HEAD)
+
+build:
+	$(DOCKER) build -t $(IMAGE_NAME):$(RELEASE) \
+		--build-arg KUBERNETES_VERSION=$(RELEASE) \
+		--build-arg CONTAINERD_VERSION=$(CONTAINERD_VERSION) .
+	$(DOCKER) tag $(IMAGE_NAME):$(RELEASE) $(IMAGE_NAME):$(TAG)
+
+push:
+	$(DOCKER) push $(IMAGE_NAME):$(RELEASE)
+	$(DOCKER) push $(IMAGE_NAME):$(TAG)


### PR DESCRIPTION
Add Docker and Make files for building a CAPMVM compatible image. The image includes `containerd`, `kubeadm`, `kubelet`, and `kubectl`. Additionally, add build and release GH action.