### PR TITLE
fix: add kernel modules to base image

### DIFF
--- a/flintlock/base-ubuntu/Dockerfile
+++ b/flintlock/base-ubuntu/Dockerfile
@@ -1,4 +1,9 @@
 ARG OS_VERSION
+ARG KERNEL_REGISTRY
+
+FROM ${KERNEL_REGISTRY}/flintlock-kernel:5.10.77 as kernel51077
+FROM ${KERNEL_REGISTRY}/flintlock-kernel:4.19.215 as kernel419215
+
 FROM ubuntu:${OS_VERSION}
 
 RUN apt-get update && apt-get install -y \
@@ -19,4 +24,9 @@ RUN apt-get update && apt-get install -y \
         wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    sed -i -e 's/^AcceptEnv LANG LC_\*$/#AcceptEnv LANG LC_*/' /etc/ssh/sshd_config
+    sed -i -e 's/^AcceptEnv LANG LC_\*$/#AcceptEnv LANG LC_*/' /etc/ssh/sshd_config && \
+    mkdir -p /lib/modules
+
+# Add modules from the 2 kernel images we support
+COPY --from=kernel51077 /lib /lib
+COPY --from=kernel419215 /lib /lib

--- a/flintlock/base-ubuntu/Makefile
+++ b/flintlock/base-ubuntu/Makefile
@@ -8,7 +8,8 @@ TAG?=$(shell git rev-parse --short HEAD)
 
 build:
 	$(DOCKER) build -t $(IMAGE_NAME):$(RELEASE) \
-		--build-arg OS_VERSION=$(RELEASE) .
+		--build-arg OS_VERSION=$(RELEASE) \
+		--build-arg KERNEL_REGISTRY=$(REGISTRY) .
 	$(DOCKER) tag $(IMAGE_NAME):$(RELEASE) $(IMAGE_NAME):$(TAG)
 
 push:


### PR DESCRIPTION
Bake the kernel modules in for our supported kernels into the base image.....feels a little hacky. We may want to consider publishing different images.

Signed-off-by: Richard Case <richard@weave.works>