### PR TITLE
fix: nodes reporting ready without cni installed

### DIFF
--- a/capmvm/kubernetes/Dockerfile
+++ b/capmvm/kubernetes/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /etc/containerd && containerd config default > /etc/containerd/config.toml
+RUN rm /etc/cni/net.d/10-containerd-net.conflist
 RUN systemctl enable containerd
 
 RUN echo '[Service] \n\


### PR DESCRIPTION
When provisioning clusters with the current image the kubernetes nodes
report ready even though a CNI hasn't been installed. This is causing
issues with coredns and other applications gettign assigned the wrong
ip which then requires that the pods are manually restarted.

On investigation its found that the containerd net CNI configuration is
present in the base image and this causes the pods to be assigned an IP
from the 10.88.x.x range, even if you don't apply a CNI.

By removing the `10-containerd-net.conflist` this means that coredns
will not be assigned an IP address until a CNI is applied. As coredns is
not scheduled the node is marked as no ready until the CNI is installed.

Signed-off-by: Richard Case <richard@weave.works>